### PR TITLE
Account for class properties

### DIFF
--- a/source/Debounce.js
+++ b/source/Debounce.js
@@ -11,10 +11,11 @@ export default function outerDecorator (duration) {
       enumerable: descriptor.enumerable,
       get: function getter () {
         // Attach this function to the instance (not the class)
+        var fn = typeof descriptor.initializer === 'function' ? descriptor.initializer.call(this) : undefined;
         Object.defineProperty(this, key, {
           configurable: true,
           enumerable: descriptor.enumerable,
-          value: debounce(descriptor.value, duration)
+          value: debounce(descriptor.value || fn, duration)
         })
 
         return this[key]


### PR DESCRIPTION
``` js
// Works
class Some {
    @debouce
    method() {}
}
```

``` js
// Doesnt work
class Some {
    @debouce
    method = () => {}
}
```

Seems like this decorator doesn't account for class instance properties as `descriptor.value` will be `undefined`. This update makes things work for me. Lemme know what you think.
